### PR TITLE
Stop criteria rework

### DIFF
--- a/include/render/common.h
+++ b/include/render/common.h
@@ -22,6 +22,7 @@ class Render;
 struct SharedContext
 {
     size_t mFrameNumber = 0;
+    size_t mSubframeIndex = 0;
     SettingsManager* mSettingsManager = nullptr;
     Render* mRender = nullptr;
 };

--- a/src/hdRunner/main.cpp
+++ b/src/hdRunner/main.cpp
@@ -669,8 +669,8 @@ int main(int argc, const char* argv[])
         auto currentTime = std::chrono::high_resolution_clock::now();
         const double deltaTime = std::chrono::duration<double, std::milli>(currentTime - prevTime).count() / 1000.0;
 
-        auto tmpCam = cameraController.getCamera();
-        auto transform = tmpCam.GetTransform();
+        GfCamera tmpCam = cameraController.getCamera();
+        GfMatrix4d transform = tmpCam.GetTransform();
 
         uint32_t cameraSpeed = ctx->mSettingsManager->getAs<uint32_t>("render/cameraSpeed");
         cameraController.update(deltaTime, cameraSpeed);
@@ -679,27 +679,27 @@ int main(int argc, const char* argv[])
         cam.SetFromCamera(cameraController.getCamera(), 0.0);
 
         display->onBeginFrame();
-        if (cameraController.getCamera().GetTransform() != transform ||
-            sppTotal != ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal") ||
-            frameSpp != ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp") ||
-            ctx->mSettingsManager->getAs<bool>("render/pt/isResized"))
-        {
-            frameSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp");
-            sppTotal = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
-            ctx->mSettingsManager->setAs<bool>("render/pt/isResized", false);
-            leftSpp = sppTotal;
-        }
+        // if (cameraController.getCamera().GetTransform() != transform ||
+        //     sppTotal != ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal") ||
+        //     frameSpp != ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp") ||
+        //     ctx->mSettingsManager->getAs<bool>("render/pt/isResized"))
+        // {
+        //     frameSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp");
+        //     sppTotal = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
+        //     ctx->mSettingsManager->setAs<bool>("render/pt/isResized", false);
+        //     leftSpp = sppTotal;
+        // }
 
         // This can be moved to render itself
-        if (leftSpp > 0)
+        // if (leftSpp > 0)
         {
             uint32_t savedFSpp = -1;
-            if (frameSpp > leftSpp)
-            {
-                savedFSpp = frameSpp;
-                ctx->mSettingsManager->setAs<uint32_t>("render/pt/spp", leftSpp);
-                frameSpp = leftSpp;
-            }
+            // if (frameSpp > leftSpp)
+            // {
+            //     savedFSpp = frameSpp;
+            //     ctx->mSettingsManager->setAs<uint32_t>("render/pt/spp", leftSpp);
+            //     frameSpp = leftSpp;
+            // }
 
             engine.Execute(renderIndex, &tasks); // main path tracing rendering in fixed render resolution
             oka::Buffer* outputBuffer =
@@ -771,8 +771,9 @@ int main(int argc, const char* argv[])
 
         surfaceController.release(versionId);
 
+        const uint32_t currentSpp = ctx->mSubframeIndex;
         display->setWindowTitle((std::string("Strelka") + " [" + std::to_string(frameTime) + " ms]" + " [" +
-                                std::to_string(iteration) + " iteration]")
+                                std::to_string(currentSpp) + " spp]")
                                    .c_str());
         ++frameCount;
     }

--- a/src/hdRunner/main.cpp
+++ b/src/hdRunner/main.cpp
@@ -729,7 +729,8 @@ int main(int argc, const char* argv[])
             }
             iteration = sppTotal - leftSpp;
         }
-
+        const uint32_t totalSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
+        const uint32_t currentSpp = ctx->mSubframeIndex;
         bool needScreenshot = ctx->mSettingsManager->getAs<bool>("render/pt/needScreenshot");
         if (needScreenshot)
         {
@@ -740,10 +741,10 @@ int main(int argc, const char* argv[])
             fileName = fileName.substr(foundSlash + 1);
 
             auto generateName = [&](const uint32_t attempt) {
-                std::string outputFilePath = fileName + "_" + std::to_string(iteration) + "i_" +
+                std::string outputFilePath = fileName + "_" + std::to_string(currentSpp) + "i_" +
                                              std::to_string(ctx->mSettingsManager->getAs<uint32_t>("render/pt/depth")) +
                                              "d_" +
-                                             std::to_string(ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp")) +
+                                             std::to_string(totalSpp) +
                                              "spp_" + std::to_string(attempt) + ".png";
                 return outputFilePath;
             };
@@ -771,7 +772,6 @@ int main(int argc, const char* argv[])
 
         surfaceController.release(versionId);
 
-        const uint32_t currentSpp = ctx->mSubframeIndex;
         display->setWindowTitle((std::string("Strelka") + " [" + std::to_string(frameTime) + " ms]" + " [" +
                                 std::to_string(currentSpp) + " spp]")
                                    .c_str());

--- a/src/hdRunner/main.cpp
+++ b/src/hdRunner/main.cpp
@@ -629,18 +629,10 @@ int main(int argc, const char* argv[])
     HdEngine engine;
 
     display->setInputHandler(&cameraController);
-
     RenderSurfaceController surfaceController(ctx->mSettingsManager, renderBuffers);
     display->setResizeHandler(&surfaceController);
 
     uint64_t frameCount = 0;
-    oka::ImageBuffer outputImageCopy;
-    uint32_t frameSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp");
-    uint32_t sppTotal = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
-    uint32_t leftSpp = sppTotal;
-    bool needCopyBuffer = false;
-    int32_t waitFramesForScreenshot = -1;
-    uint32_t iteration = sppTotal - leftSpp;
 
     while (!display->windowShouldClose())
     {
@@ -669,9 +661,6 @@ int main(int argc, const char* argv[])
         auto currentTime = std::chrono::high_resolution_clock::now();
         const double deltaTime = std::chrono::duration<double, std::milli>(currentTime - prevTime).count() / 1000.0;
 
-        GfCamera tmpCam = cameraController.getCamera();
-        GfMatrix4d transform = tmpCam.GetTransform();
-
         uint32_t cameraSpeed = ctx->mSettingsManager->getAs<uint32_t>("render/cameraSpeed");
         cameraController.update(deltaTime, cameraSpeed);
         prevTime = currentTime;
@@ -679,59 +668,30 @@ int main(int argc, const char* argv[])
         cam.SetFromCamera(cameraController.getCamera(), 0.0);
 
         display->onBeginFrame();
-        // if (cameraController.getCamera().GetTransform() != transform ||
-        //     sppTotal != ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal") ||
-        //     frameSpp != ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp") ||
-        //     ctx->mSettingsManager->getAs<bool>("render/pt/isResized"))
-        // {
-        //     frameSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/spp");
-        //     sppTotal = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
-        //     ctx->mSettingsManager->setAs<bool>("render/pt/isResized", false);
-        //     leftSpp = sppTotal;
-        // }
 
-        // This can be moved to render itself
-        // if (leftSpp > 0)
-        {
-            uint32_t savedFSpp = -1;
-            // if (frameSpp > leftSpp)
-            // {
-            //     savedFSpp = frameSpp;
-            //     ctx->mSettingsManager->setAs<uint32_t>("render/pt/spp", leftSpp);
-            //     frameSpp = leftSpp;
-            // }
+        engine.Execute(renderIndex, &tasks); // main path tracing rendering in fixed render resolution
+        oka::Buffer* outputBuffer =
+            surfaceController.getRenderBuffer(versionId)->GetResource(false).UncheckedGet<oka::Buffer*>();
+        oka::ImageBuffer outputImage;
+        // upload to host
+        outputBuffer->map();
+        outputImage.data = outputBuffer->getHostPointer();
+        outputImage.dataSize = outputBuffer->getHostDataSize();
+        outputImage.height = outputBuffer->height();
+        outputImage.width = outputBuffer->width();
+        outputImage.pixel_format = outputBuffer->getFormat();
 
-            engine.Execute(renderIndex, &tasks); // main path tracing rendering in fixed render resolution
-            oka::Buffer* outputBuffer =
-                surfaceController.getRenderBuffer(versionId)->GetResource(false).UncheckedGet<oka::Buffer*>();
-            oka::ImageBuffer outputImage;
-            // upload to host
-            outputBuffer->map();
-            outputImage.data = outputBuffer->getHostPointer();
-            outputImage.dataSize = outputBuffer->getHostDataSize();
-            outputImage.height = outputBuffer->height();
-            outputImage.width = outputBuffer->width();
-            outputImage.pixel_format = outputBuffer->getFormat();
-            outputImageCopy = outputImage;
-
-            leftSpp -= frameSpp;
-
-            if (savedFSpp != -1)
-            {
-                frameSpp = savedFSpp;
-                ctx->mSettingsManager->setAs<uint32_t>("render/pt/spp", frameSpp);
-            }
-
-            if (leftSpp == 0 && ctx->mSettingsManager->getAs<bool>("render/pt/screenshotSPP"))
-            {
-                ctx->mSettingsManager->setAs<bool>("render/pt/needScreenshot", true);
-                ctx->mSettingsManager->setAs<bool>("render/pt/screenshotSPP", false);
-            }
-            iteration = sppTotal - leftSpp;
-        }
         const uint32_t totalSpp = ctx->mSettingsManager->getAs<uint32_t>("render/pt/sppTotal");
         const uint32_t currentSpp = ctx->mSubframeIndex;
         bool needScreenshot = ctx->mSettingsManager->getAs<bool>("render/pt/needScreenshot");
+
+        if (ctx->mSettingsManager->getAs<bool>("render/pt/screenshotSPP") && (currentSpp == totalSpp))
+        {
+            needScreenshot = true;
+            // need to store screen only once
+            ctx->mSettingsManager->setAs<bool>("render/pt/screenshotSPP", false);
+        }
+    
         if (needScreenshot)
         {
             std::size_t foundSlash = usdPath.find_last_of("/\\");
@@ -755,15 +715,15 @@ int main(int argc, const char* argv[])
                 outputFilePath = generateName(attempt++);
             } while (std::filesystem::exists(std::filesystem::path(outputFilePath.c_str())));
 
-            unsigned char* mappedMem = (unsigned char*)outputImageCopy.data;
+            unsigned char* mappedMem = (unsigned char*)outputImage.data;
 
-            if (saveScreenshot(outputFilePath, mappedMem, outputImageCopy.width, outputImageCopy.height))
+            if (saveScreenshot(outputFilePath, mappedMem, outputImage.width, outputImage.height))
             {
                 ctx->mSettingsManager->setAs<bool>("render/pt/needScreenshot", false);
             }
         }
 
-        display->drawFrame(outputImageCopy); // blit rendered image to swapchain
+        display->drawFrame(outputImage); // blit rendered image to swapchain
         display->drawUI(); // render ui to swapchain image in window resolution
         display->onEndFrame(); // submit command buffer and present
 

--- a/src/render/optix/OptiXRender.cpp
+++ b/src/render/optix/OptiXRender.cpp
@@ -829,7 +829,7 @@ void OptiXRender::updatePathtracerParams(const uint32_t width, const uint32_t he
         // new dimensions!
         needRealloc = true;
         // reset rendering
-        getSharedContext().mFrameNumber = 0;
+        getSharedContext().mSubframeIndex = 0;
     }
     mState.params.image_width = width;
     mState.params.image_height = height;
@@ -875,7 +875,7 @@ void OptiXRender::render(Buffer* output)
     camera.updateAspectRatio(width / (float)height);
     camera.updateViewMatrix();
 
-    View currView;
+    View currView = {};
 
     currView.mCamMatrices = camera.matrices;
 
@@ -883,7 +883,7 @@ void OptiXRender::render(Buffer* output)
         glm::any(glm::notEqual(currView.mCamMatrices.view, mPrevView.mCamMatrices.view)))
     {
         // need reset
-        getSharedContext().mFrameNumber = 0;
+        getSharedContext().mSubframeIndex = 0;
     }
 
     ::Camera cam;
@@ -904,17 +904,40 @@ void OptiXRender::render(Buffer* output)
     params.max_depth = settings.getAs<uint32_t>("render/pt/depth");
 
     params.rectLightSamplingMethod = settings.getAs<uint32_t>("render/pt/rectLightSamplingMethod");
+    params.enableAccumulation = settings.getAs<bool>("render/pt/enableAcc");
+    params.debug = settings.getAs<uint32_t>("render/pt/debug");
+    params.shadowRayTmin = settings.getAs<float>("render/pt/dev/shadowRayTmin");
+    params.materialRayTmin = settings.getAs<float>("render/pt/dev/materialRayTmin");
 
     params.viewToWorld = glm::inverse(camera.matrices.view);
     params.clipToView = camera.matrices.invPerspective;
 
-    if (mState.prevParams.rectLightSamplingMethod != params.rectLightSamplingMethod)
+    bool settingsChanged = false;
+
+    static uint32_t rectLightSamplingMethodPrev = 0;
+    const uint32_t rectLightSamplingMethod = settings.getAs<uint32_t>("render/pt/rectLightSamplingMethod");
+    settingsChanged = (rectLightSamplingMethodPrev != rectLightSamplingMethod);
+    rectLightSamplingMethodPrev = rectLightSamplingMethod;
+
+    static bool enableAccumulationPrev = 0;
+    const bool enableAccumulation = settings.getAs<bool>("render/pt/enableAcc");
+    settingsChanged |= (enableAccumulationPrev != enableAccumulation);
+    enableAccumulationPrev = enableAccumulation;
+
+    static uint32_t sspTotalPrev = 0;
+    const uint32_t sspTotal = settings.getAs<uint32_t>("render/pt/sppTotal");
+    settingsChanged |= (sspTotalPrev > sspTotal); // reset only if new spp less than already accumulated
+    sspTotalPrev = sspTotal;
+
+    const float gamma = settings.getAs<float>("render/post/gamma");
+    const ToneMapperType tonemapperType = (ToneMapperType)settings.getAs<uint32_t>("render/pt/tonemapperType");
+
+    if (settingsChanged)
     {
-        // need reset
-        getSharedContext().mFrameNumber = 0;
+        getSharedContext().mSubframeIndex = 0;
     }
 
-    params.subframe_index = getSharedContext().mFrameNumber;
+    params.subframe_index = getSharedContext().mSubframeIndex;
 
     glm::float3 cam_u, cam_v, cam_w;
     cam.UVWFrame(cam_u, cam_v, cam_w);
@@ -923,19 +946,37 @@ void OptiXRender::render(Buffer* output)
     params.cam_v = make_float3(cam_v.x, cam_v.y, cam_v.z);
     params.cam_w = make_float3(cam_w.x, cam_w.y, cam_w.z);
 
-    params.enableAccumulation = settings.getAs<bool>("render/pt/enableAcc");
-    params.debug = settings.getAs<uint32_t>("render/pt/debug");
-    params.shadowRayTmin = settings.getAs<float>("render/pt/dev/shadowRayTmin");
-    params.materialRayTmin = settings.getAs<float>("render/pt/dev/materialRayTmin");
-
     CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(mState.d_params), &params, sizeof(params), cudaMemcpyHostToDevice));
 
-    OPTIX_CHECK(optixLaunch(
-        mState.pipeline, mState.stream, mState.d_params, sizeof(Params), &mState.sbt, width, height, /*depth=*/1));
-    CUDA_SYNC_CHECK();
+    const uint32_t totalSpp = settings.getAs<uint32_t>("render/pt/sppTotal");
+    const uint32_t samplesPerLaunch = settings.getAs<uint32_t>("render/pt/spp");
+    const int32_t leftSpp = totalSpp - getSharedContext().mSubframeIndex;
+    // if accumulation is off then launch selected samples per pixel
+    const uint32_t samplesThisLaunch =
+        enableAccumulation ? std::min((int32_t)samplesPerLaunch, leftSpp) : samplesPerLaunch;
+    params.samples_per_launch = samplesThisLaunch;
+    if (samplesThisLaunch != 0)
+    {
+        OPTIX_CHECK(optixLaunch(
+            mState.pipeline, mState.stream, mState.d_params, sizeof(Params), &mState.sbt, width, height, /*depth=*/1));
+        CUDA_SYNC_CHECK();
+        if (enableAccumulation)
+        {
+            getSharedContext().mSubframeIndex += samplesThisLaunch;
+        }
+        else
+        {
+            getSharedContext().mSubframeIndex = samplesThisLaunch;
+        }
+    }
+    else
+    {
+        // just copy latest accumulated raw radiance to destination
+        CUDA_CHECK(cudaMemcpy(params.image, params.accum,
+                              mState.params.image_width * mState.params.image_height * sizeof(float4),
+                              cudaMemcpyDeviceToDevice));
+    }
 
-    const float gamma = settings.getAs<float>("render/post/gamma");
-    const ToneMapperType tonemapperType = (ToneMapperType) settings.getAs<uint32_t>("render/pt/tonemapperType");
     tonemap(tonemapperType, gamma, params.image, width, height);
 
     output->unmap();

--- a/src/render/optix/OptixRenderParams.h
+++ b/src/render/optix/OptixRenderParams.h
@@ -51,8 +51,6 @@ struct Params
 
     uint32_t rectLightSamplingMethod;
 
-    float3 cam_eye;
-    float3 cam_u, cam_v, cam_w;
     glm::float4x4 clipToView;
     glm::float4x4 viewToWorld;
 


### PR DESCRIPTION
Fixed: mouse move triggers render reset
moved checking total samples inside renderers for better control

In OptiX if total samples per pixel accumulated then we copy accumulated buffer and apply tonemapper